### PR TITLE
fix: yml to yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Update the configuration file with appropriate values for *SourceRepo, ApprovalT
 Once the configuration file has been updated, execute the following command to create the CloudFormation stack which will create the required CodePipeline.
 
 ```bash
-aws cloudformation create-stack --stack-name automated-ui-testing --template-body file://automated-ui-testing.yml --parameters file://automated-ui-testing-params.json --capabilities CAPABILITY_NAMED_IAM
+aws cloudformation create-stack --stack-name automated-ui-testing --template-body file://automated-ui-testing.yaml --parameters file://automated-ui-testing-params.json --capabilities CAPABILITY_NAMED_IAM
 ```
 
 Once the CloudFormation successfully creates the stack, it would have created a CodePipeline with similar stages as shown below.


### PR DESCRIPTION
The readme command not working by the following reason.
 [Errno 2] No such file or directory: 'automated-ui-testing.yml'

We should replace yml to yaml

*Issue #, if available:*
I try to run the README.md command, but it not working by the following reason.

```bash
$ aws cloudformation create-stack --stack-name automated-ui-testing --template-body file://automated-ui-testing.yml --parameters file://automated-ui-testing-params.json --capabilities CAPABILITY_NAMED_IAM

Error parsing parameter '--template-body': Unable to load paramfile file://automated-ui-testing.yml: [Errno 2] No such file or directory: 'automated-ui-testing.yml'
```

When replace `yml` to `yaml`, it works.

```bash
$ aws cloudformation create-stack --stack-name automated-ui-testing --template-body file://automated-ui-testing.yaml --parameters file://automated-ui-testing-params.json --capabilities CAPABILITY_NAMED_IAM
{
    "StackId": "arn:aws:cloudformation:us-east-1:9999999999:stack/automated-ui-testing/b5ddf160-75e6-11e9-bd46-0eee31812ac2"
}
```

*Description of changes:*

Just replace example command on the README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
